### PR TITLE
Expose all mappers in the registry

### DIFF
--- a/src/main/java/com/newrelic/jfr/ToMetricRegistry.java
+++ b/src/main/java/com/newrelic/jfr/ToMetricRegistry.java
@@ -1,5 +1,8 @@
 package com.newrelic.jfr;
 
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toUnmodifiableList;
+
 import com.newrelic.jfr.tometric.AllocationRequiringGCMapper;
 import com.newrelic.jfr.tometric.CPUThreadLoadMapper;
 import com.newrelic.jfr.tometric.ContextSwitchRateMapper;
@@ -9,68 +12,63 @@ import com.newrelic.jfr.tometric.GarbageCollectionMapper;
 import com.newrelic.jfr.tometric.MetaspaceSummaryMapper;
 import com.newrelic.jfr.tometric.OverallCPULoadMapper;
 import com.newrelic.jfr.tometric.ThreadAllocationStatisticsMapper;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toUnmodifiableList;
-
 public class ToMetricRegistry {
 
-    private final static List<EventToMetric> ALL_MAPPERS =
-            List.of(
-                    new AllocationRequiringGCMapper(),
-                    new ContextSwitchRateMapper(),
-                    new CPUThreadLoadMapper(),
-                    new GarbageCollectionMapper(),
-                    new GCHeapSummaryMapper(),
-                    new MetaspaceSummaryMapper(),
-                    new OverallCPULoadMapper(),
-                    new ThreadAllocationStatisticsMapper()
-            );
-    private final List<EventToMetric> mappers;
+  private static final List<EventToMetric> ALL_MAPPERS =
+      List.of(
+          new AllocationRequiringGCMapper(),
+          new ContextSwitchRateMapper(),
+          new CPUThreadLoadMapper(),
+          new GarbageCollectionMapper(),
+          new GCHeapSummaryMapper(),
+          new MetaspaceSummaryMapper(),
+          new OverallCPULoadMapper(),
+          new ThreadAllocationStatisticsMapper());
+  private final List<EventToMetric> mappers;
 
+  private ToMetricRegistry(List<EventToMetric> mappers) {
+    this.mappers = new ArrayList<>(mappers);
+  }
 
-    private ToMetricRegistry(List<EventToMetric> mappers) {
-        this.mappers = new ArrayList<>(mappers);
-    }
+  public static ToMetricRegistry createDefault() {
+    return create(allEventNames());
+  }
 
-    public static ToMetricRegistry createDefault() {
-        return create(allEventNames());
-    }
+  public static ToMetricRegistry create(Collection<String> eventNames) {
+    var filtered =
+        ALL_MAPPERS
+            .stream()
+            .filter(mapper -> eventNames.contains(mapper.getEventName()))
+            .collect(toList());
+    return new ToMetricRegistry(filtered);
+  }
 
-    public static ToMetricRegistry create(Collection<String> eventNames) {
-        var filtered = ALL_MAPPERS.stream()
-                        .filter(mapper -> eventNames.contains(mapper.getEventName()))
-                        .collect(toList());
-        return new ToMetricRegistry(filtered);
-    }
+  private static List<String> allEventNames() {
+    return ALL_MAPPERS.stream().map(EventToMetric::getEventName).collect(toUnmodifiableList());
+  }
 
-    private static List<String> allEventNames() {
-        return ALL_MAPPERS.stream()
-                .map(EventToMetric::getEventName)
-                .collect(toUnmodifiableList());
-    }
+  /** @return a stream of all EventToMetric entries in this registry. */
+  public Stream<EventToMetric> all() {
+    return mappers.stream();
+  }
 
-    /**
-     * @return a stream of all EventToMetric entries in this registry.
-     */
-    public Stream<EventToMetric> all() {
-        return mappers.stream();
-    }
-
-    /**
-     * Returns an Optional<EventToMetric> containing the mapper with the given
-     * JFR event name.  If the event is not known to this registry, the
-     * returned Optional will be empty.
-     * @param eventName - the JFR name of the event to find
-     * @return - an optional EventToMetric.
-     */
-    public Optional<EventToMetric> get(String eventName) {
-        return mappers.stream().filter(toMetric -> toMetric.getEventName().equals(eventName)).findFirst();
-    }
+  /**
+   * Returns an Optional<EventToMetric> containing the mapper with the given JFR event name. If the
+   * event is not known to this registry, the returned Optional will be empty.
+   *
+   * @param eventName - the JFR name of the event to find
+   * @return - an optional EventToMetric.
+   */
+  public Optional<EventToMetric> get(String eventName) {
+    return mappers
+        .stream()
+        .filter(toMetric -> toMetric.getEventName().equals(eventName))
+        .findFirst();
+  }
 }

--- a/src/test/java/com/newrelic/jfr/ToMetricRegistryTest.java
+++ b/src/test/java/com/newrelic/jfr/ToMetricRegistryTest.java
@@ -1,39 +1,43 @@
 package com.newrelic.jfr;
 
-import com.newrelic.jfr.tometric.CPUThreadLoadMapper;
-import com.newrelic.jfr.tometric.EventToMetric;
-import com.newrelic.jfr.tometric.GCHeapSummaryMapper;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.newrelic.jfr.tometric.CPUThreadLoadMapper;
+import com.newrelic.jfr.tometric.EventToMetric;
+import com.newrelic.jfr.tometric.GCHeapSummaryMapper;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
 class ToMetricRegistryTest {
 
-    @Test
-    void testUnknownNamesDropped() {
-        var names = List.of("unknown1", CPUThreadLoadMapper.EVENT_NAME, "unknown2",
-                GCHeapSummaryMapper.EVENT_NAME, "unknown3");
+  @Test
+  void testUnknownNamesDropped() {
+    var names =
+        List.of(
+            "unknown1",
+            CPUThreadLoadMapper.EVENT_NAME,
+            "unknown2",
+            GCHeapSummaryMapper.EVENT_NAME,
+            "unknown3");
 
-        var expected = List.of(CPUThreadLoadMapper.EVENT_NAME, GCHeapSummaryMapper.EVENT_NAME);
-        ToMetricRegistry registry = ToMetricRegistry.create(names);
+    var expected = List.of(CPUThreadLoadMapper.EVENT_NAME, GCHeapSummaryMapper.EVENT_NAME);
+    ToMetricRegistry registry = ToMetricRegistry.create(names);
 
-        var actual = registry.all().map(EventToMetric::getEventName).collect(toList());
-        assertEquals(expected, actual);
-    }
+    var actual = registry.all().map(EventToMetric::getEventName).collect(toList());
+    assertEquals(expected, actual);
+  }
 
-    @Test
-    void testGetUnknown() {
-        ToMetricRegistry registry = ToMetricRegistry.createDefault();
-        assertTrue(registry.get("nope").isEmpty());
-    }
+  @Test
+  void testGetUnknown() {
+    ToMetricRegistry registry = ToMetricRegistry.createDefault();
+    assertTrue(registry.get("nope").isEmpty());
+  }
 
-    @Test
-    void testGetKnown() {
-        ToMetricRegistry registry = ToMetricRegistry.createDefault();
-        assertTrue(registry.get(CPUThreadLoadMapper.EVENT_NAME).isPresent());
-    }
+  @Test
+  void testGetKnown() {
+    ToMetricRegistry registry = ToMetricRegistry.createDefault();
+    assertTrue(registry.get(CPUThreadLoadMapper.EVENT_NAME).isPresent());
+  }
 }

--- a/src/test/java/com/newrelic/jfr/ToMetricRegistryTest.java
+++ b/src/test/java/com/newrelic/jfr/ToMetricRegistryTest.java
@@ -1,0 +1,39 @@
+package com.newrelic.jfr;
+
+import com.newrelic.jfr.tometric.CPUThreadLoadMapper;
+import com.newrelic.jfr.tometric.EventToMetric;
+import com.newrelic.jfr.tometric.GCHeapSummaryMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ToMetricRegistryTest {
+
+    @Test
+    void testUnknownNamesDropped() {
+        var names = List.of("unknown1", CPUThreadLoadMapper.EVENT_NAME, "unknown2",
+                GCHeapSummaryMapper.EVENT_NAME, "unknown3");
+
+        var expected = List.of(CPUThreadLoadMapper.EVENT_NAME, GCHeapSummaryMapper.EVENT_NAME);
+        ToMetricRegistry registry = ToMetricRegistry.create(names);
+
+        var actual = registry.all().map(EventToMetric::getEventName).collect(toList());
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testGetUnknown() {
+        ToMetricRegistry registry = ToMetricRegistry.createDefault();
+        assertTrue(registry.get("nope").isEmpty());
+    }
+
+    @Test
+    void testGetKnown() {
+        ToMetricRegistry registry = ToMetricRegistry.createDefault();
+        assertTrue(registry.get(CPUThreadLoadMapper.EVENT_NAME).isPresent());
+    }
+}


### PR DESCRIPTION
In trying to use this in another component, it was discovered that individual mappers in this registry are not exposed.  This prevents the streaming JFR user from setting up callbacks for all known supported types.  The `ToMetricRegistry.all()` method now exposes this.

This was also an opportunity to simplify away from the `Map` which used redundant names.  The registry is considered configuration and is not expected to be used in the critical path, which is why the `List` suffices.  If a user intends to violate this, they can still build their own map by leveraging the stream (but it should be discouraged).