### PR TITLE
Expose summary mappers

### DIFF
--- a/src/main/java/com/newrelic/jfr/ToSummaryRegistry.java
+++ b/src/main/java/com/newrelic/jfr/ToSummaryRegistry.java
@@ -1,19 +1,18 @@
 package com.newrelic.jfr;
 
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toUnmodifiableList;
+
 import com.newrelic.jfr.tosummary.EventToSummary;
 import com.newrelic.jfr.tosummary.G1GarbageCollectionSummarizer;
 import com.newrelic.jfr.tosummary.NetworkReadSummarizer;
 import com.newrelic.jfr.tosummary.NetworkWriteSummarizer;
 import com.newrelic.jfr.tosummary.ObjectAllocationInNewTLABSummarizer;
 import com.newrelic.jfr.tosummary.ObjectAllocationOutsideTLABSummarizer;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toUnmodifiableList;
 
 public class ToSummaryRegistry {
 

--- a/src/main/java/com/newrelic/jfr/ToSummaryRegistry.java
+++ b/src/main/java/com/newrelic/jfr/ToSummaryRegistry.java
@@ -17,45 +17,42 @@ import static java.util.stream.Collectors.toUnmodifiableList;
 
 public class ToSummaryRegistry {
 
-    private final static List<EventToSummary> ALL_MAPPERS = List.of(
-            new G1GarbageCollectionSummarizer(),
-            new NetworkReadSummarizer(),
-            new NetworkWriteSummarizer(),
-            new ObjectAllocationInNewTLABSummarizer(),
-            new ObjectAllocationOutsideTLABSummarizer()
-    );
+  private static final List<EventToSummary> ALL_MAPPERS =
+      List.of(
+          new G1GarbageCollectionSummarizer(),
+          new NetworkReadSummarizer(),
+          new NetworkWriteSummarizer(),
+          new ObjectAllocationInNewTLABSummarizer(),
+          new ObjectAllocationOutsideTLABSummarizer());
 
-    private final List<EventToSummary> mappers;
+  private final List<EventToSummary> mappers;
 
-    private ToSummaryRegistry(List<EventToSummary> mappers) {
-        this.mappers = mappers;
-    }
+  private ToSummaryRegistry(List<EventToSummary> mappers) {
+    this.mappers = mappers;
+  }
 
-    public static ToSummaryRegistry createDefault() {
-        return new ToSummaryRegistry(ALL_MAPPERS);
-    }
+  public static ToSummaryRegistry createDefault() {
+    return new ToSummaryRegistry(ALL_MAPPERS);
+  }
 
-    public static ToSummaryRegistry create(Collection<String> eventNames) {
-        var filtered =
-                ALL_MAPPERS
-                        .stream()
-                        .filter(mapper -> eventNames.contains(mapper.getEventName()))
-                        .collect(toList());
-        return new ToSummaryRegistry(filtered);
-    }
+  public static ToSummaryRegistry create(Collection<String> eventNames) {
+    var filtered =
+        ALL_MAPPERS
+            .stream()
+            .filter(mapper -> eventNames.contains(mapper.getEventName()))
+            .collect(toList());
+    return new ToSummaryRegistry(filtered);
+  }
 
+  private static List<String> allEventNames() {
+    return ALL_MAPPERS.stream().map(EventToSummary::getEventName).collect(toUnmodifiableList());
+  }
 
-    private static List<String> allEventNames() {
-        return ALL_MAPPERS.stream().map(EventToSummary::getEventName).collect(toUnmodifiableList());
-    }
+  public Stream<EventToSummary> all() {
+    return mappers.stream();
+  }
 
-    public Stream<EventToSummary> all() {
-        return mappers.stream();
-    }
-
-    public Optional<EventToSummary> get(String eventName) {
-        return mappers.stream()
-        .filter(m -> m.getEventName().equals(eventName))
-        .findFirst();
-    }
+  public Optional<EventToSummary> get(String eventName) {
+    return mappers.stream().filter(m -> m.getEventName().equals(eventName)).findFirst();
+  }
 }

--- a/src/test/java/com/newrelic/jfr/ToSummaryRegistryTest.java
+++ b/src/test/java/com/newrelic/jfr/ToSummaryRegistryTest.java
@@ -1,0 +1,45 @@
+package com.newrelic.jfr;
+
+import com.newrelic.jfr.tosummary.EventToSummary;
+import com.newrelic.jfr.tosummary.G1GarbageCollectionSummarizer;
+import com.newrelic.jfr.tosummary.NetworkReadSummarizer;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ToSummaryRegistryTest {
+
+  @Test
+  void testUnknownNamesDropped() {
+    var names =
+        List.of(
+            "unknown1",
+            G1GarbageCollectionSummarizer.EVENT_NAME,
+            "unknown2",
+            NetworkReadSummarizer.EVENT_NAME,
+            "unknown3");
+
+    var expected =
+        List.of(G1GarbageCollectionSummarizer.EVENT_NAME, NetworkReadSummarizer.EVENT_NAME);
+    ToSummaryRegistry registry = ToSummaryRegistry.create(names);
+
+    var actual = registry.all().map(EventToSummary::getEventName).collect(toList());
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testGetUnknown() {
+    ToSummaryRegistry registry = ToSummaryRegistry.createDefault();
+    assertTrue(registry.get("NOT gonna find me").isEmpty());
+  }
+
+  @Test
+  void testGetKnown() {
+    ToSummaryRegistry registry = ToSummaryRegistry.createDefault();
+    assertTrue(registry.get(NetworkReadSummarizer.EVENT_NAME).isPresent());
+  }
+}

--- a/src/test/java/com/newrelic/jfr/ToSummaryRegistryTest.java
+++ b/src/test/java/com/newrelic/jfr/ToSummaryRegistryTest.java
@@ -1,15 +1,14 @@
 package com.newrelic.jfr;
 
-import com.newrelic.jfr.tosummary.EventToSummary;
-import com.newrelic.jfr.tosummary.G1GarbageCollectionSummarizer;
-import com.newrelic.jfr.tosummary.NetworkReadSummarizer;
-import org.junit.jupiter.api.Test;
-
-import java.util.List;
-
 import static java.util.stream.Collectors.toList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.newrelic.jfr.tosummary.EventToSummary;
+import com.newrelic.jfr.tosummary.G1GarbageCollectionSummarizer;
+import com.newrelic.jfr.tosummary.NetworkReadSummarizer;
+import java.util.List;
+import org.junit.jupiter.api.Test;
 
 class ToSummaryRegistryTest {
 


### PR DESCRIPTION
This changes the shape of the `ToSummaryRegistry` to look more like the `ToMetricRegistry`, but also needed to expose all mappers for users to hook up for streaming JFR.